### PR TITLE
fix timezone format for correct parsing in strptime when python <= 3.6

### DIFF
--- a/i3-agenda.py
+++ b/i3-agenda.py
@@ -86,6 +86,9 @@ def get_unix_time(full_time):
     else: 
         format = '%Y-%m-%d'
 
+    if full_time[-3] == ":":
+        full_time = full_time[:-3]+full_time[-2:]
+
     return time.mktime(datetime.datetime.strptime(full_time, format).timetuple())
 
 def get_closest(events):


### PR DESCRIPTION
Python introduced the ability to parse "`:`" in the timezone format (in `strptime()`) only from version 3.7  and up.
With this ugly but working hack you can avoid the strptime parsing error. 

Probably a better way would be to catch the ParseError exception...

See https://stackoverflow.com/questions/30999230/how-to-parse-timezone-with-colon for more information