### PR TITLE
basic support for i3blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,11 @@ bar {
 Example output of the script:  
 ```11:00 Grocery shopping```
 
+Example i3block configuration
+```
+[i3-agenda]
+command=/usr/bin/python3 ~/.config/i3blocks/scripts/i3-agenda.py -c ~/.google_credentials.json -ttl 60
+interval=60
+```
+
 ![example](art/screenshot.png)

--- a/i3-agenda.py
+++ b/i3-agenda.py
@@ -11,10 +11,14 @@ from googleapiclient.discovery import build
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.auth.transport.requests import Request
 import argparse
+import os
+import subprocess
 
 SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
 TMP_TOKEN = '/tmp/i3agenda_google_token.pickle'
 CACHE_PATH = '/tmp/i3agenda_cache.txt'
+
+button = os.getenv("BLOCK_BUTTON", "nope") # i3blocks use this envvar to check the click
 
 parser = argparse.ArgumentParser(description='Show next Google Calendar event')
 parser.add_argument('--credentials', '-c', type=str,
@@ -39,7 +43,9 @@ class EventEncoder(json.JSONEncoder):
 def main():
     args = parser.parse_args()
 
-
+    if button is not "":
+        subprocess.Popen(["xdg-open", "https://calendar.google.com/calendar/r/day"])
+        
     events = load_cache(args.cachettl)
     if events == None:
         service = connect(args.credentials)

--- a/i3-agenda.py
+++ b/i3-agenda.py
@@ -18,7 +18,7 @@ SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
 TMP_TOKEN = '/tmp/i3agenda_google_token.pickle'
 CACHE_PATH = '/tmp/i3agenda_cache.txt'
 
-button = os.getenv("BLOCK_BUTTON", "nope") # i3blocks use this envvar to check the click
+button = os.getenv("BLOCK_BUTTON", "") # i3blocks use this envvar to check the click
 
 parser = argparse.ArgumentParser(description='Show next Google Calendar event')
 parser.add_argument('--credentials', '-c', type=str,

--- a/i3-agenda.py
+++ b/i3-agenda.py
@@ -17,6 +17,7 @@ import subprocess
 SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
 TMP_TOKEN = '/tmp/i3agenda_google_token.pickle'
 CACHE_PATH = '/tmp/i3agenda_cache.txt'
+DEFAULT_CAL_WEBPAGE = 'https://calendar.google.com/calendar/r/day'
 
 button = os.getenv("BLOCK_BUTTON", "") # i3blocks use this envvar to check the click
 
@@ -44,7 +45,7 @@ def main():
     args = parser.parse_args()
 
     if button is not "":
-        subprocess.Popen(["xdg-open", "https://calendar.google.com/calendar/r/day"])
+        subprocess.Popen(["xdg-open", DEFAULT_CAL_WEBPAGE])
         
     events = load_cache(args.cachettl)
     if events == None:


### PR DESCRIPTION
I've added basic support for i3blocks use (https://github.com/vivien/i3blocks).

Is a very simple check on a environment variable that opens the default browser (with `xdg-open`) at the daily calendar page. 
This is the way i3blocks uses to check if the item has been clicked.