### PR TITLE
Allow filtering events only from certain calendars

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,12 @@ bar {
 Example output of the script:  
 ```11:00 Grocery shopping```
 
+## Filter displayed calendars
+
+To display events only from certain calendars the variable `allowed_calendars_ids` at the beginning of the script can be populated inserting the list of ids (as string) of the calendars you are interested in.
+
+To obtain the calendar id you can check the settings page of the calendar on Google (usually is the owner email, if it's not shared).
+
+Leaving the list empty will fetch all calendars (default behavior).
+
 ![example](art/screenshot.png)

--- a/i3-agenda.py
+++ b/i3-agenda.py
@@ -16,6 +16,8 @@ SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
 TMP_TOKEN = '/tmp/i3agenda_google_token.pickle'
 CACHE_PATH = '/tmp/i3agenda_cache.txt'
 
+allowed_calendars_ids = [] # populate with the Google Calendar IDs you are interested in
+
 parser = argparse.ArgumentParser(description='Show next Google Calendar event')
 parser.add_argument('--credentials', '-c', type=str,
                    help='path to your credentials.json file')
@@ -57,7 +59,8 @@ def getEvents(service):
     while True:
         calendar_list = service.calendarList().list().execute()
         for calendar_list_entry in calendar_list['items']:
-            calendar_ids.append(calendar_list_entry['id'])
+            if not allowed_calendars_ids or calendar_list_entry['id'] in allowed_calendars_ids:
+                calendar_ids.append(calendar_list_entry['id'])
         page_token = calendar_list.get('nextPageToken')
         if not page_token:
             break


### PR DESCRIPTION
I've defined a list at the beginning of the script that can be populated with the calendar ids you want to fetch only.

If the list is empty the behavior remains the same (default, fetch all calendars).