### PR TITLE
Display the event date.

### DIFF
--- a/i3_agenda/__init__.py
+++ b/i3_agenda/__init__.py
@@ -59,7 +59,7 @@ def main():
     closest = get_closest(events)
         
     t = datetime.datetime.fromtimestamp(closest[0])
-    print(f"{t:%H:%M} " + get_display(closest[1]) )
+    print(f"{t:%Y-%m-%d@%H:%M} " + get_display(closest[1]) )
 
 def getEvents(service):
     now = datetime.datetime.utcnow().isoformat() + 'Z' # 'Z' indicates UTC time


### PR DESCRIPTION
The format will be YYYY-mm-dd@HH:MM.

This can be made prettier, but it's still better than skipping the event
date altogether.

Resolves https://github.com/rosenpin/i3-agenda/issues/19.