### PR TITLE
Add a --no-event-text option

### DIFF
--- a/i3_agenda/__init__.py
+++ b/i3_agenda/__init__.py
@@ -53,6 +53,10 @@ parser.add_argument('--maxres',
                     type=int,
                     default=10, 
                     help='max number of events to query Google\'s API for each of your calendars. Increase this number if you have lot of events in your google calendar')
+parser.add_argument('--no-event-text',
+                    default="No events",
+                    metavar="TEXT",
+                    help='text to display when there are no events')
 
 class Event():
     def __init__(self, summary: str, is_allday: bool, unix_time: float, end_time: float):
@@ -85,7 +89,7 @@ def main():
 
     closest = get_closest(events)
     if closest is None:
-        print("No events")
+        print(args.no_event_text)
         return
 
     t = datetime.datetime.fromtimestamp(closest.unix_time)


### PR DESCRIPTION
This is my last tweak to adapt i3-agenda to my liking.

I'm nor sure what to add to the README.
Perhaps it would make more sense to put a dump of the help directly in the README so as potential user can get a quick glance about what's configurable without having to install the software.

Oh, and thank you for publishing i3-agenda. It is useful !