### PR TITLE
Correct the cache ttl logic

### DIFF
--- a/i3_agenda/__init__.py
+++ b/i3_agenda/__init__.py
@@ -186,7 +186,7 @@ def load_cache(cachettl: int) -> Optional[List[Event]]:
     if not os.path.exists(CACHE_PATH):
         return None
 
-    if os.path.getmtime(CACHE_PATH) - time.time() > cachettl * 60:
+    if time.time() - os.path.getmtime(CACHE_PATH) > cachettl * 60:
         return None
 
     events = []


### PR DESCRIPTION
Before the value compared to cachettl was always negative
and the thus the cache was always used independently
of the cachettl value

close #38