### PR TITLE
add aiohttp as dependency, support python-google-auth 1.22

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setuptools.setup(
         "python-bidi",
         "google-api-python-client",
         "google-auth-httplib2",
-        "google-auth-oauthlib"
+        "google-auth-oauthlib",
+        "aiohttp"
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
 python-google-auth 1.22 breaks the program, but it looks like this fixes it.