### PR TITLE
Set "busy" for private events from shared calendars

### DIFF
--- a/i3_agenda/__init__.py
+++ b/i3_agenda/__init__.py
@@ -170,7 +170,16 @@ def getEvents(service, allowed_calendars_ids: List[str], max_results: int, today
             if 'location' in event:
                 location = event['location']
 
-            all.append(Event(event['summary'],
+            # Events from shared calendars with their visibility set to private
+            # will not have any summary. In Google Calendar they show up as
+            # "busy". Maybe we want to do the same here? Or maybe we want to
+            # skip this event altogether?
+            try:
+                summary = event['summary']
+            except KeyError:
+                summary = "busy"
+
+            all.append(Event(summary,
                              is_allday(start_time),
                              unix_time,
                              end_time,


### PR DESCRIPTION
Fixes #41. 

It turns out that when an external calendar is shared with the calendar being queried, the `summary` field is empty for private events from that calendar. On the calendar being queried, the event shows up as `busy` in the browser. 

I'm not sure if this is the best approach. But based on feedback, I'd be happy to reiterate on this!