### PR TITLE
Limit Size of Summary by the Number of Chars

### DIFF
--- a/i3_agenda/__init__.py
+++ b/i3_agenda/__init__.py
@@ -70,7 +70,11 @@ parser.add_argument('--date-format',
                     type=str,
                     default="%%d/%%m",
                     help='the date format like %%d/%%m/%%y. Default is %%d/%%m')
-
+parser.add_argument('--limchar',
+                    '-l',
+                    type=int,
+                    default=-1,
+                    help='the max characters that the displayed event can contain')
 
 class Event():
     def __init__(self, summary: str, is_allday: bool, unix_time: float, end_time: float, location: str):
@@ -119,6 +123,9 @@ def main():
     tomorrow = datetime.datetime.today() + datetime.timedelta(days=1)
 
     result = str(get_display(closest.summary))
+
+    if args.limchar!=-1 and len(result)>args.limchar:
+        result = ''.join([c for c in result][:args.limchar])+'...'
 
     if (event.date() == today.date()):
         print(f"{event:%H:%M} " + result)

--- a/i3_agenda/__init__.py
+++ b/i3_agenda/__init__.py
@@ -124,8 +124,8 @@ def main():
 
     result = str(get_display(closest.summary))
 
-    if args.limchar!=-1 and len(result)>args.limchar:
-        result = ''.join([c for c in result][:args.limchar])+'...'
+    if args.limchar >= 0 and len(result) > args.limchar:
+        result = ''.join([c for c in result][:args.limchar]) + '...'
 
     if (event.date() == today.date()):
         print(f"{event:%H:%M} " + result)


### PR DESCRIPTION
Adding a command line argument to limit the size of the summary, so if the summary was "meeting with costumer" and you set the limit to 7, using `-l 7`, the summary displayed turns to "meeting...". This brings a more organized i3bar with i3-agenda.