### PR TITLE
fix date exception on 'is_this_week' function

### DIFF
--- a/i3_agenda/event.py
+++ b/i3_agenda/event.py
@@ -52,7 +52,7 @@ class Event:
 
     def is_this_week(self):
         next_week = dt.datetime.today() + dt.timedelta(days=7)
-        return self.get_datetime() < next_week.date()
+        return self.get_datetime().date() < next_week.date()
 
     def is_urgent(self):
         now = dt.datetime.now()


### PR DESCRIPTION
fixed an exception on fetching the next week events (TypeError: can't compare datetime.datetime to datetime.date)