### PR TITLE
add skip flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,15 @@ Edit the polybar configuration creating two modules:
 type = custom/ipc
 
 hook-0 = i3-agenda -c ~/.google_credentials.json --skip $(cat ~/.config/i3-agenda/i3-agenda-skip.tmp || echo 0)
-hook-1 = ~/.config/polybar/scripts/i3agenda-onscroll.sh down && i3-agenda -c ~/.google_credentials.json --update --skip $(cat ~/.config/i3-agenda/i3-agenda-skip.tmp || echo 0)
-hook-2 = ~/.config/polybar/scripts/i3agenda-onscroll.sh up && i3-agenda -c ~/.google_credentials.json --update --skip $(cat ~/.config/i3-agenda/i3-agenda-skip.tmp || echo 0)
+hook-1 = ~/.config/polybar/scripts/i3agenda-onscroll.sh down && i3-agenda -c ~/.google_credentials.json --skip $(cat ~/.config/i3-agenda/i3-agenda-skip.tmp || echo 0)
+hook-2 = ~/.config/polybar/scripts/i3agenda-onscroll.sh up && i3-agenda -c ~/.google_credentials.json --skip $(cat ~/.config/i3-agenda/i3-agenda-skip.tmp || echo 0)
 
 format = %{F#61afef}%{F-} <output>
 
 ; left click to launch Google Calendar
 click-left = firefox https://calendar.google.com/calendar/u/0/r
 ; right click force update the cache, if for example you just added a new event
-click-right = rm ~/.config/i3-agenda/i3-agenda-skip.tmp; python3 ~/.config/i3-agenda/i3-agenda-src/i3_agenda/__init__.py -cd ~/.config/i3-agenda/ -c ~/.config/i3-agenda/client_secret.json --update && notify-send "i3-agenda" "Sync completed"
+click-right = rm ~/.config/i3-agenda/i3-agenda-skip.tmp; i3-agenda -c ~/.config/i3-agenda/client_secret.json --update && notify-send "i3-agenda" "Sync completed"
 
 ; show the previous event
 scroll-down = polybar-msg hook agenda-ipc 2

--- a/README.md
+++ b/README.md
@@ -58,17 +58,18 @@ Run `sudo pip3 install python-bidi google-api-python-client google-auth-httplib2
                         time for cache to be kept in minutes
   --update, -u          when using this flag it will not load previous results from cache, it will however save new results to cache. You can use this flag to refresh all the cache forcefully
   --ids IDS [IDS ...], -i IDS [IDS ...]
-                        list of calendar ids to fetch, space separated. If none is specified all calendars will be fetched
+                        list of calendar ids to fetch, space separated. If  none is specified all calendars will be fetched
   --maxres MAXRES, -r MAXRES
                         max number of events to query Google's API for each of your calendars. Increase this number if you have lot of events in your google calendar
   --today, -d           print only today events
   --no-event-text TEXT  text to display when there are no events
-  --hide-event-after MINUTES
+  --hide-event-after HIDE_EVENT_AFTER
                         minutes to show events after they start before showing the next event. If not specified, the current event will be shown until it ends
-  --date-format DATEFORMAT
+  --date-format DATE_FORMAT
                         the date format like %d/%m/%y. Default is %d/%m
-  --limchar LIMIT, -l LIMIT
-                        limits the size of the event summary string in LIMIT characters. If not specified it shows the entire summary.
+  --limchar LIMCHAR, -l LIMCHAR
+                        the max characters that the displayed event can contain
+  --skip SKIP, -s SKIP  the number of events to skip from the most recent
 ```
 
 ### Filter displayed calendars

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ interval = 60
 ```
 
 Example i3block configuration:
-```
+```ini
 [i3-agenda]
 command=i3-agenda -c ~/.google_credentials.json -ttl 60
 interval=60
@@ -111,3 +111,56 @@ interval=60
 
 Example output of the script:\
 ```10:55 Grocery shopping```
+
+### How to use the `skip` flag to scroll events
+
+Edit the polybar configuration creating two modules:
+
+```ini
+[module/agenda-ipc]
+type = custom/ipc
+
+hook-0 = i3-agenda -c ~/.google_credentials.json --skip $(cat ~/.config/i3-agenda/i3-agenda-skip.tmp || echo 0)
+hook-1 = ~/.config/polybar/scripts/i3agenda-onscroll.sh down && i3-agenda -c ~/.google_credentials.json --update --skip $(cat ~/.config/i3-agenda/i3-agenda-skip.tmp || echo 0)
+hook-2 = ~/.config/polybar/scripts/i3agenda-onscroll.sh up && i3-agenda -c ~/.google_credentials.json --update --skip $(cat ~/.config/i3-agenda/i3-agenda-skip.tmp || echo 0)
+
+format = %{F#61afef}%{F-} <output>
+
+; left click to launch Google Calendar
+click-left = firefox https://calendar.google.com/calendar/u/0/r
+; right click force update the cache, if for example you just added a new event
+click-right = rm ~/.config/i3-agenda/i3-agenda-skip.tmp; python3 ~/.config/i3-agenda/i3-agenda-src/i3_agenda/__init__.py -cd ~/.config/i3-agenda/ -c ~/.config/i3-agenda/client_secret.json --update && notify-send "i3-agenda" "Sync completed"
+
+; show the previous event
+scroll-down = polybar-msg hook agenda-ipc 2
+; show the next event
+scroll-up = polybar-msg hook agenda-ipc 3
+
+[module/agenda]
+type = custom/script
+interval = 900
+exec = polybar-msg hook agenda-ipc 1
+label =
+```
+
+Add both modules to the bar, for example:
+
+```ini
+modules-center = agenda agenda-ipc
+```
+
+In the polybar scripts folder add the file `i3agenda-onscroll.sh`:
+
+```bash
+#!/usr/bin/env bash
+if [ -n "${1}" ]; then
+  file=~/.config/i3-agenda/i3-agenda-skip.tmp
+  typeset -i skip=$(cat $file || echo 0)
+  if [[ "${1}" == "up" ]]; then
+    skip+=1
+  elif [[ "${1}" == "down" && $skip -gt 0 ]]; then
+    skip=$(( skip - 1))
+  fi
+  echo $skip > $file
+fi
+```

--- a/i3_agenda/__init__.py
+++ b/i3_agenda/__init__.py
@@ -38,6 +38,8 @@ def main():
     args = parser.parse_args()
 
     events = load_events(args)
+    if args.skip > 0:
+        events = events[args.skip :]
 
     closest = get_closest(events, args.hide_event_after)
     if closest is None:

--- a/i3_agenda/config.py
+++ b/i3_agenda/config.py
@@ -78,3 +78,10 @@ parser.add_argument(
     default=-1,
     help="the max characters that the displayed event can contain",
 )
+parser.add_argument(
+    "--skip",
+    "-s",
+    type=int,
+    default=0,
+    help="the number of events to skip from the most recent",
+)


### PR DESCRIPTION
Ref: https://github.com/rosenpin/i3-agenda/issues/63

Using the IPC module no cron or external script (except the bash to save the event index) is required and no overhead is created.