### PR TITLE
Ongoing event support (+RTL fixes)

### DIFF
--- a/i3_agenda/event.py
+++ b/i3_agenda/event.py
@@ -31,28 +31,27 @@ class Event:
         event_datetime = self.get_datetime()
 
         result = self.summary
-        shortend = False
+        trimmed = False
         if 0 <= limit_char < len(result):
-            shortend = True
+            trimmed = True
             result = "".join([c for c in result][:limit_char])
 
         result = str(get_display(result))
-        if shortend:
+        # this is done to preserve RTL while adding the "..." since the get_display is applied after adding the "..."
+        if trimmed:
             result += "..."
 
         if self.is_ongoing():
             time_left = self.get_end_datetime() - dt.datetime.now()
-            hours_left = str(time_left).split(".", 2)[0].split(":", 3)[0]
-            minutes_left = str(time_left).split(".", 2)[0].split(":", 3)[1]
-            return result + " (" + hours_left + "h " + minutes_left + "m left)"
+            return f"{result} ({human_delta(time_left)} left)"
         elif self.is_today():
-            return f"{event_datetime:%H:%M} " + result
+            return f"{event_datetime:%H:%M} {result}"
         elif self.is_tomorrow():
-            return f"{event_datetime:Tomorrow at %H:%M} " + result
+            return f"{event_datetime:Tomorrow at %H:%M} {result}"
         elif self.is_this_week():
-            return f"{event_datetime:%a at %H:%M} " + result
+            return f"{event_datetime:%a at %H:%M} {result}"
         else:
-            return f"{event_datetime:{date_format} at %H:%M} " + result
+            return f"{event_datetime:{date_format} at %H:%M} {result}"
 
     def is_ongoing(self):
         now = dt.datetime.now()
@@ -91,6 +90,23 @@ class EventEncoder(json.JSONEncoder):
             return o.__dict__
         else:
             return json.JSONEncoder.default(self, o)
+
+
+def human_delta(tdelta):
+    d = dict(days=tdelta.days)
+    d["hrs"], rem = divmod(tdelta.seconds, 3600)
+    d["min"], d["sec"] = divmod(rem, 60)
+
+    if d["min"] == 0:
+        fmt = "0m"
+    elif d["hrs"] == 0:
+        fmt = "{min}m"
+    elif d["days"] == 0:
+        fmt = "{hrs}h {min}m"
+    else:
+        fmt = "{days} day(s) {hrs}h {min}m"
+
+    return fmt.format(**d)
 
 
 def get_closest(events: List[Event], hide_event_after: int) -> Optional[Event]:


### PR DESCRIPTION
This PR includes

* Ongoing event support - if an event is on going, print the event + (time left).
Example: Work Out (22m left)
* RTL fixes
Specifically, when limchar is active, the "..." would be shown before the event name in RTL languages. This should now be fixed
* Minor refactoring 