### PR TITLE
Fix bug in `--today` when not in UTC timezone

### DIFF
--- a/i3_agenda/__init__.py
+++ b/i3_agenda/__init__.py
@@ -24,7 +24,7 @@ def button_action(button_code: str, closest: Event):
 
 
 def filter_only_todays_events(events: List[Event]) -> Optional[List[Event]]:
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now()
     midnight_rfc3339 = now.replace(hour=23, minute=59, second=59)
     return list(
         filter(


### PR DESCRIPTION
Currently `--today` checks if the event is within the day, but day is
defined by UTC. I think this makes more sense to use local time, as UTC
has no significance in this context (IMO, anyhow).