### PR TITLE
Add new `--next-event-time-left` flag to show time left before next event

### DIFF
--- a/i3_agenda/__init__.py
+++ b/i3_agenda/__init__.py
@@ -71,7 +71,7 @@ def main():
 
     button_action(config.button, closest)
 
-    print(closest.get_string(args.limchar, args.date_format, args.ongoing_time_left))
+    print(closest.get_string(args.limchar, args.date_format, args.ongoing_time_left, args.next_event_time_left))
 
     if closest.is_urgent():
         # special i3blocks exit code to set the block urgent

--- a/i3_agenda/config.py
+++ b/i3_agenda/config.py
@@ -105,3 +105,9 @@ parser.add_argument(
     action="store_true",
     help="print time left instead of the end time for ongoing events (22m left) instead of (ends 12:00)",
 )
+parser.add_argument(
+    "--next-event-time-left",
+    "-n",
+    action="store_true",
+    help="print the time remaining before the next event starts (event_name in 22m) instead of (12:00 event_name)",
+)

--- a/i3_agenda/event.py
+++ b/i3_agenda/event.py
@@ -28,7 +28,11 @@ class Event:
         return dt.datetime.fromtimestamp(self.end_time)
 
     def get_string(
-        self, limit_char: int, date_format: str, ongoing_time_left: bool = False
+        self,
+        limit_char: int,
+        date_format: str,
+        ongoing_time_left: bool = False,
+        next_event_time_left: bool = False,
     ) -> str:
         event_datetime = self.get_datetime()
 
@@ -50,7 +54,11 @@ class Event:
             else:
                 return f"{result} (ends {self.get_end_datetime():%H:%M})"
         elif self.is_today():
-            return f"{event_datetime:%H:%M} {result}"
+            if not self.is_ongoing() and next_event_time_left:
+                time_left = event_datetime - dt.datetime.now()
+                return f"{result} in {human_delta(time_left)}"
+            else:
+                return f"{event_datetime:%H:%M} {result}"
         elif self.is_tomorrow():
             return f"{event_datetime:Tomorrow at %H:%M} {result}"
         elif self.is_this_week():


### PR DESCRIPTION
This PR introduce a new flag called `--next-event-time-left`. This allows a user to see how much time is left before the next event occurs.

Current behavior without the new flag:
Current time: 11:10. The next event starts at 12:00. Output: `12:00 EventName`

With the new flag enabled:
Current time: 11:10. The next event starts at 12:00. Output: `EventName in 50m`

I hope this new feature looks handy for someone. Let me know if I have to change something. Thank you!