### PR TITLE
Handle entries with no title

### DIFF
--- a/i3_agenda/event.py
+++ b/i3_agenda/event.py
@@ -193,5 +193,4 @@ def from_json(event_json) -> Event:
     elif "description" in event_json:
         matches = re.findall(URL_REGEX, event_json["description"])
         location = matches[0][0] if matches else None
-
-    return Event(event_json["summary"], start_time, end_time, location)
+    return Event(event_json.get("summary", "(No title)"), start_time, end_time, location)


### PR DESCRIPTION
It is valid to create cal entries with no title. When this happens, we
get a key error trying to retrieve it.

In the gcal UI, "(No title)" is used as the filler, so the same is used
here.